### PR TITLE
shorten default MonetDB.R() timeout= to 60 seconds?

### DIFF
--- a/R/dbi.R
+++ b/R/dbi.R
@@ -27,7 +27,7 @@ setMethod("dbGetInfo", "MonetDBDriver", def=function(dbObj, ...)
 
 # shorthand for connecting to the DB, very handy, e.g. dbListTables(mc("acs"))
 mc <- function(dbname="demo", user="monetdb", password="monetdb", host="localhost", port=50000L, 
-               timeout=86400L, wait=FALSE, language="sql", ...) {
+               timeout=60L, wait=FALSE, language="sql", ...) {
   
   dbConnect(MonetDB.R(), dbname, user, password, host, port, timeout, wait, language, ...)
 }
@@ -38,7 +38,7 @@ ml <- function(...) {
 }
 
 setMethod("dbConnect", "MonetDBDriver", def=function(drv, dbname="demo", user="monetdb", 
-                                                     password="monetdb", host="localhost", port=50000L, timeout=86400L, wait=FALSE, language="sql", embedded=FALSE,
+                                                     password="monetdb", host="localhost", port=50000L, timeout=60L, wait=FALSE, language="sql", embedded=FALSE,
                                                      ..., url="") {
   
   if (substring(url, 1, 10) == "monetdb://" || substring(url, 1, 12) == "monetdblite:") {


### PR DESCRIPTION
what do you think about this change?  i think the current defaults confuse users since it will hang without any information.  people often want `wait=TRUE` instead.  the only utility of `timeout=` as far as i can tell is when there's a heavy processor load and it really needs time to open the socket?  another alternative is defaulting to `wait=TRUE`

here's the potential problem--

	# if no server open..
	library(DBI)
	con <- dbConnect( MonetDBLite::MonetDB.R() )
	# ..this will hang for 86400 seconds and then crash.

	# even if you open up a server during that time period,
	# the server will not recognize it.


	# if you run this..
	library(DBI)
	con <- dbConnect( MonetDBLite::MonetDB.R() , timeout = 120 )
	# .. and open up an external mserver right away
	# it will still timeout and crash.