### PR TITLE
fixed db_save_query for temporary flag

### DIFF
--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -86,8 +86,19 @@ db_insert_into.MonetDBConnection <- function(con, table, values, ...) {
 
 db_save_query.MonetDBConnection <- function(con, sql, name, temporary = TRUE,
                                             ...) {
-  tt_sql <- dplyr::build_sql("CREATE TEMPORARY TABLE ", dplyr::ident(name), " AS ",
-    sql, " WITH DATA ON COMMIT PRESERVE ROWS", con = con)
+  tt_sql <- if(isTRUE(temporary)){
+    dplyr::build_sql( "CREATE TEMPORARY TABLE "
+                      , dplyr::ident(name)
+                      , " AS ", sql, " WITH DATA ON COMMIT PRESERVE ROWS"
+                      , con = con
+    )
+  } else {
+    dplyr::build_sql( "CREATE TABLE "
+                      , dplyr::ident(name)
+                      , " AS ", sql, " WITH DATA"
+                      , con = con
+    )
+  }
   DBI::dbGetQuery(con, tt_sql)
   name
 }


### PR DESCRIPTION
The temporary flag was not working, thereby causing `dplyr::compute(temporary=FALSE)` to only create temporary tables.

This change should fix the following problem:
(mwe)
```R
library(MonetDBLite)
library(dplyr)
sc <- src_monetdblite("./db")
iris_tbl <- copy_to(sc, iris)
compute(iris_tbl, "iris_permanent", temporary=FALSE)
sc <- NULL
sc <- src_monetdblite("./db")
# is iris_permanent still there?
sc
```