### PR TITLE
fixes https://github.com/hannesmuehleisen/MonetDBLite/issues/16

### DIFF
--- a/R/dbi.R
+++ b/R/dbi.R
@@ -233,7 +233,7 @@ setMethod("dbGetException", "MonetDBConnection", def=function(conn, ...) {
 })
 
 setMethod("dbReadTable", signature(conn="MonetDBConnection", name = "character"), def=function(conn, name, ...) {
-  name <- quoteIfNeeded(conn, name)
+  name <- quoteIfNeeded(conn, name, warn=F)
   if (!dbExistsTable(conn, name))
     stop(paste0("Unknown table: ", name));
   dbGetQuery(conn, paste0("SELECT * FROM ", name), ...)
@@ -562,7 +562,7 @@ setMethod("dbDataType", signature(dbObj="MonetDBConnection", obj = "ANY"), def =
 
 
 setMethod("dbRemoveTable", signature(conn="MonetDBConnection", name = "character"), def=function(conn, name, ...) {
-  name <- quoteIfNeeded(conn, name)
+  name <- quoteIfNeeded(conn, name, warn=F)
   if (!dbExistsTable(conn, name)) stop("No such table: ", name)
   dbExecute(conn, paste("DROP TABLE", name))
   return(invisible(TRUE))


### PR DESCRIPTION
using master branch-- two unnecessary warnings

 > library(DBI)
 > db <- dbConnect(MonetDBLite::MonetDBLite())
 > dbWriteTable( db , 'IRIS' , iris )
 Identifier(s) "IRIS" contain uppercase or reserved SQL characters and need(s) to be quoted in queries.
 Identifier(s) "Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species" contain uppercase or reserved SQL characters and need(s) to be quoted in queries.
 > head( dbReadTable( db , 'IRIS' ) )
 Identifier(s) "IRIS" contain uppercase or reserved SQL characters and need(s) to be quoted in queries.
   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
 1          5.1         3.5          1.4         0.2  setosa
 2          4.9         3.0          1.4         0.2  setosa
 3          4.7         3.2          1.3         0.2  setosa
 4          4.6         3.1          1.5         0.2  setosa
 5          5.0         3.6          1.4         0.2  setosa
 6          5.4         3.9          1.7         0.4  setosa
 > dbRemoveTable( db , 'IRIS' )
 Identifier(s) "IRIS" contain uppercase or reserved SQL characters and need(s) to be quoted in queries.
 > 


using this branch-- zero unnecessary warnings
 
 devtools::install_github("hannesmuehleisen/MonetDBLite",ref="noquotewarn")

 > library(DBI)
 > db <- dbConnect(MonetDBLite::MonetDBLite())
 > dbWriteTable( db , 'IRIS' , iris )
 Identifier(s) "IRIS" contain uppercase or reserved SQL characters and need(s) to be quoted in queries.
 Identifier(s) "Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species" contain uppercase or reserved SQL characters and need(s) to be quoted in queries.
 > head( dbReadTable( db , 'IRIS' ) )
   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
 1          5.1         3.5          1.4         0.2  setosa
 2          4.9         3.0          1.4         0.2  setosa
 3          4.7         3.2          1.3         0.2  setosa
 4          4.6         3.1          1.5         0.2  setosa
 5          5.0         3.6          1.4         0.2  setosa
 6          5.4         3.9          1.7         0.4  setosa
 > dbRemoveTable( db , 'IRIS' )
