### PR TITLE
fixes https://github.com/hannesmuehleisen/MonetDBLite/issues/112

### DIFF
--- a/R/dbi.R
+++ b/R/dbi.R
@@ -1036,7 +1036,7 @@ monet.read.csv <- monetdb.read.csv <- function(conn, files, tablename, header=TR
       }
       names(headers[[1]]) <- quoteIfNeeded(conn, col.names)
     }
-    dbWriteTable(conn, tablename, headers[[1]][FALSE, ], transaction=F)
+    dbWriteTable(conn, tablename, headers[[1]][FALSE, ,drop=FALSE], transaction=F)
   }
   
   delimspec <- paste0("USING DELIMITERS '", delim, "','", newline, "','", quote, "'")


### PR DESCRIPTION
one-column csv files now import correctly

	> dbWriteTable( db , 'iris2' , tf )
	Treating character vector parameter as file name(s) for monetdb.read.csv()
	Identifier(s) "Species" contain uppercase or reserved SQL characters and need(s) to be quoted in queries.

