### PR TITLE
appveyor test-build all branches not ending in -C or -Java

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,9 @@ install:
 shallow_clone: true
 
 branches:
-  only:
-    - master
-    - Jul2017Lite-R
-    - Jul2017Lite-R-Makefile
+    except:
+      - /.*-Java/
+      - /.*-C/
 
 environment:
 #  global:


### PR DESCRIPTION
i think (but am not sure) this is why you added the restriction?  i think this change allows most patches/pull requests to be tested? thanks
https://github.com/hannesmuehleisen/MonetDBLite/branches